### PR TITLE
perf: apply Haversine formula at the DB layer instead of API layer

### DIFF
--- a/app/search/_components/station-card.tsx
+++ b/app/search/_components/station-card.tsx
@@ -42,7 +42,7 @@ export const StationCard = ({ station, primaryFuelType, lowestPrice, tankSize }:
                 </div>
                 <Button variant="outline" className="ml-auto self-start" size="sm" asChild>
                     <a href={`https://maps.google.com/?saddr=Current+Location&daddr=${encodeURIComponent(station.address)}`} target="_blank" rel="noopener noreferrer">
-                        <MapPinned className="mr-1 h-4 w-4" />{station.distance}km
+                        <MapPinned className="mr-1 h-4 w-4" />{station.distance.toFixed(1)}km
                     </a>
                 </Button>
             </CardHeader>

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -58,12 +58,6 @@ export default async function SearchPage({
         });
         const stations = await executeQueryWithSentry(findStationsQuery);
 
-        // const stationsWithDistanceMiddle = stations.map(station => ({
-        //     ...station,
-        //     distance: parseFloat(haversineDistance(parsedLat!, parsedLong!, station.latitude, station.longitude).toFixed(1))
-        // }))
-        //     .filter(station => station.distance <= parsedRadius);
-
         if (stations.length === 0) {
             // TODO: Update to use something like https://github.com/rapideditor/country-coder when supporting more states.
             // Rough bounds for NSW.
@@ -94,34 +88,6 @@ export default async function SearchPage({
                 </div>
             )
         }
-
-        // const stationsWithDistanceAgainQuery = db.query.stations.findMany({
-        //     with: {
-        //         prices: {
-        //             // Trying to reduce the size returned as more prices are retrieved by ordering
-        //             // by ID assuming the later prices are more recent and then limiting to 15.
-        //             orderBy: (prices, { desc }) => [desc(prices.id)],
-        //             limit: 10
-        //         }
-        //     },
-        //     where: (station, { inArray }) => inArray(station.id, stationsWithDistanceMiddle.map(station => station.id))
-        // });
-
-        // const stationsWithDistanceAgain = await executeQueryWithSentry(stationsWithDistanceAgainQuery)
-
-        // if (stationsWithDistanceAgain.length === 0) {
-        //     return (
-        //         <div className="flex flex-col items-center justify-center gap-y-4 h-full">
-        //             <div className="flex flex-col gap-y-2 text-center">
-        //                 <h2 className="text-2xl font-bold">No fuel stations found</h2>
-        //                 <Balance className="text-gray-500 mx-auto flex max-w-[980px] flex-col items-center">Try increasing the search radius. You can click the button below to check out fuel prices in Sydney to see what it looks like!</Balance>
-        //                 <Link href="/search?lat=-33.8930404&long=151.2765367" className={cn(buttonVariants())}>
-        //                     <Navigation className="mr-1 h-4 w-4" /> Check out fuel prices in Sydney
-        //                 </Link>
-        //             </div>
-        //         </div>
-        //     )
-        // }
 
         const stationsWithDistance = stations.map(station => {
             const uniquePrices = station.prices.reduce((acc: { [key: string]: any }, price) => {

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -6,9 +6,8 @@ import Link from "next/link";
 import { buttonVariants } from "@/components/ui/button";
 import { Navigation } from "lucide-react";
 import Balance from "react-wrap-balancer"
-import { getStations } from "@/lib/stations";
-
-export const revalidate = 43200 // revalidate the data at most every 12 hours
+import { stations as stationsSchema } from "@/lib/db/schema";
+import { sql, lte } from 'drizzle-orm'
 
 export default async function SearchPage({
     searchParams
@@ -35,15 +34,37 @@ export default async function SearchPage({
     }
 
     if (parsedLat !== null && parsedLong !== null && fuelType && parsedRadius && parsedTankSize && sortBy) {
-        const stations = await getStations();
+        const findStationsQuery = db.query.stations.findMany({
+            extras: {
+                distance: sql<number>`
+                6371 * acos(
+                    cos(radians(${parsedLat}))
+                    * cos(radians(${stationsSchema.latitude}))
+                    * cos(radians(${stationsSchema.longitude}) - radians(${parsedLong}))
+                    + sin(radians(${parsedLat}))
+                    * sin(radians(${stationsSchema.latitude}))
+                  )
+                `.as('distance')
+            },
+            where: (lte(sql`distance`, parsedRadius)),
+            with: {
+                prices: {
+                    // Trying to reduce the size returned as more prices are retrieved by ordering
+                    // by ID assuming the later prices are more recent and then limiting to 15.
+                    orderBy: (prices, { desc }) => [desc(prices.id)],
+                    limit: 10
+                }
+            },
+        });
+        const stations = await executeQueryWithSentry(findStationsQuery);
 
-        const stationsWithDistanceMiddle = stations.map(station => ({
-            ...station,
-            distance: parseFloat(haversineDistance(parsedLat!, parsedLong!, station.latitude, station.longitude).toFixed(1))
-        }))
-            .filter(station => station.distance <= parsedRadius);
+        // const stationsWithDistanceMiddle = stations.map(station => ({
+        //     ...station,
+        //     distance: parseFloat(haversineDistance(parsedLat!, parsedLong!, station.latitude, station.longitude).toFixed(1))
+        // }))
+        //     .filter(station => station.distance <= parsedRadius);
 
-        if (stationsWithDistanceMiddle.length === 0) {
+        if (stations.length === 0) {
             // TODO: Update to use something like https://github.com/rapideditor/country-coder when supporting more states.
             // Rough bounds for NSW.
             if (parsedLat < -37.505 || parsedLat > -28.157 || parsedLong < 140.999 || parsedLong > 153.552) {
@@ -74,35 +95,35 @@ export default async function SearchPage({
             )
         }
 
-        const stationsWithDistanceAgainQuery = db.query.stations.findMany({
-            with: {
-                prices: {
-                    // Trying to reduce the size returned as more prices are retrieved by ordering
-                    // by ID assuming the later prices are more recent and then limiting to 15.
-                    orderBy: (prices, { desc }) => [desc(prices.id)],
-                    limit: 10
-                }
-            },
-            where: (station, { inArray }) => inArray(station.id, stationsWithDistanceMiddle.map(station => station.id))
-        });
+        // const stationsWithDistanceAgainQuery = db.query.stations.findMany({
+        //     with: {
+        //         prices: {
+        //             // Trying to reduce the size returned as more prices are retrieved by ordering
+        //             // by ID assuming the later prices are more recent and then limiting to 15.
+        //             orderBy: (prices, { desc }) => [desc(prices.id)],
+        //             limit: 10
+        //         }
+        //     },
+        //     where: (station, { inArray }) => inArray(station.id, stationsWithDistanceMiddle.map(station => station.id))
+        // });
 
-        const stationsWithDistanceAgain = await executeQueryWithSentry(stationsWithDistanceAgainQuery)
+        // const stationsWithDistanceAgain = await executeQueryWithSentry(stationsWithDistanceAgainQuery)
 
-        if (stationsWithDistanceAgain.length === 0) {
-            return (
-                <div className="flex flex-col items-center justify-center gap-y-4 h-full">
-                    <div className="flex flex-col gap-y-2 text-center">
-                        <h2 className="text-2xl font-bold">No fuel stations found</h2>
-                        <Balance className="text-gray-500 mx-auto flex max-w-[980px] flex-col items-center">Try increasing the search radius. You can click the button below to check out fuel prices in Sydney to see what it looks like!</Balance>
-                        <Link href="/search?lat=-33.8930404&long=151.2765367" className={cn(buttonVariants())}>
-                            <Navigation className="mr-1 h-4 w-4" /> Check out fuel prices in Sydney
-                        </Link>
-                    </div>
-                </div>
-            )
-        }
+        // if (stationsWithDistanceAgain.length === 0) {
+        //     return (
+        //         <div className="flex flex-col items-center justify-center gap-y-4 h-full">
+        //             <div className="flex flex-col gap-y-2 text-center">
+        //                 <h2 className="text-2xl font-bold">No fuel stations found</h2>
+        //                 <Balance className="text-gray-500 mx-auto flex max-w-[980px] flex-col items-center">Try increasing the search radius. You can click the button below to check out fuel prices in Sydney to see what it looks like!</Balance>
+        //                 <Link href="/search?lat=-33.8930404&long=151.2765367" className={cn(buttonVariants())}>
+        //                     <Navigation className="mr-1 h-4 w-4" /> Check out fuel prices in Sydney
+        //                 </Link>
+        //             </div>
+        //         </div>
+        //     )
+        // }
 
-        const stationsWithDistance = stationsWithDistanceAgain.map(station => {
+        const stationsWithDistance = stations.map(station => {
             const uniquePrices = station.prices.reduce((acc: { [key: string]: any }, price) => {
                 if (!acc[price.fuelType] || new Date(price.lastUpdatedUTC) > new Date(acc[price.fuelType].lastUpdatedUTC)) {
                     acc[price.fuelType] = price;
@@ -112,7 +133,7 @@ export default async function SearchPage({
 
             return {
                 ...station,
-                distance: stationsWithDistanceMiddle.find(s => s.id === station.id)?.distance ?? 0,
+                distance: stations.find(s => s.id === station.id)?.distance ?? 0,
                 prices: Object.values(uniquePrices)
             };
         })

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -5,11 +5,9 @@ export default {
     schema: "./lib/db/schema.ts",
     out: "./lib/db/migrations",
     driver: "turso",
-    dbCredentials: env.NODE_ENV === "production" ? {
+    dbCredentials: {
         url: env.DATABASE_URL,
         authToken: env.DATABASE_AUTH_TOKEN
-    } : {
-        url: env.DATABASE_URL
     },
     verbose: true,
     strict: true

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -3,9 +3,9 @@ import { createClient } from '@libsql/client';
 import { env } from '../env.mjs';
 import * as schema from './schema';
 
-const client = env.NODE_ENV === 'development' ? createClient({
+const client = createClient({
     url: env.DATABASE_URL,
     authToken: env.DATABASE_AUTH_TOKEN
-}) : createClient({ url: env.DATABASE_URL });
+});
 
 export const db = drizzle(client, { schema });

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -3,7 +3,7 @@ import { createClient } from '@libsql/client';
 import { env } from '../env.mjs';
 import * as schema from './schema';
 
-const client = env.NODE_ENV === 'production' ? createClient({
+const client = env.NODE_ENV === 'development' ? createClient({
     url: env.DATABASE_URL,
     authToken: env.DATABASE_AUTH_TOKEN
 }) : createClient({ url: env.DATABASE_URL });


### PR DESCRIPTION
Here's hoping, applying the Haversine formula will increase the performance of the `/search` page by reducing the number of DB calls from 2 to 1 and doing this computation at the DB layer instead of the API layer.